### PR TITLE
updating merge request to patch file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "composer-exit-on-patch-failure": true,
     "patches": {
       "drupal/core": {
-        "Catch-All routes (#2741939)": "https://git.drupalcode.org/project/drupal/-/merge_requests/443/diffs.patch",
+        "Catch-All routes (#2741939)": "https://www.drupal.org/files/issues/2022-11-23/2741939-48.patch",
         "Wrong language field labels after drupal_rebuild()": "https://www.drupal.org/files/issues/2021-12-01/3221375-27-workaround.patch"
       }
     }


### PR DESCRIPTION
When trying to use `proxy-drupal-core` I got:
> Could not apply patch!

Most likely as the merge request being used has been changed and no longer applies nicely, instead we should use a patch file to make sure it stays the same.